### PR TITLE
update hbase version in pom.xml to 0.94.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase</artifactId>
-            <version>0.92.1</version>
+            <version>0.94.3</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Since we are strongly recommend to use hbase which version higher than 0.94.3, version of hbase in pom.xml should be 0.94.3.

See:
Haeinsa WIki: https://github.com/VCNC/haeinsa/wiki/How-to-Use
Issue on HBase: https://issues.apache.org/jira/browse/HBASE-7051
