### PR TITLE
Fix maven thrift plugin bugs on build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -408,5 +408,36 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.thrift.tools</groupId>
+                        <artifactId>maven-thrift-plugin</artifactId>
+                        <version>0.1.11</version>
+                        <executions>
+                            <execution>
+                                <id>thrift-sources</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>thrift-test-sources</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Only v0.1.11 of maven-thrift-plugin only is on maven central. We should use v0.1.11.
And default profile should be exists for other os. (which is not mac or windows)
Developer who build Haeinsa in linux, he/she should build thrift him/herself.

See README file of maven-thrift-plugin:
https://github.com/dtrott/maven-thrift-plugin
