### PR TITLE
Exclude hadoop-common snapshot dependency from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,12 @@
             <artifactId>hadoop-hdfs-test</artifactId>
             <version>0.22.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hadoop-common</artifactId>
+                    <groupId>org.apache.hadoop</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Currently test (maybe arbitrary) fails on Travis-CI.

`hadoop-hdfs-test:0.22.0:test` depends on `hadoop-hdfs:0.22.0`. And `hadoop-hdfs:0.22.0` depends on `hadoop-common:0.22.0-SNAPSHOT`. But it seemt to `hadoop-common:0.22.0-SNAPSHOT` is not possible to resolve in Travis-CI. Check more information about [hadoop-hdfs-test](http://mvnrepository.com/artifact/org.apache.hadoop/hadoop-hdfs-test/0.22.0) and [hadoop-hdfs](http://mvnrepository.com/artifact/org.apache.hadoop/hadoop-hdfs/0.22.0) artifacts from maven central repository.

"404 - GroupItemNotFoundException" error can be seen when tries to get `hadoop-common:0.22.0-SNAPSHOT` from central snapshot repository:
https://repository.apache.org/snapshots/org/apache/hadoop/hadoop-common/0.22.0-SNAPSHOT/hadoop-common-0.22.0-SNAPSHOT.pom

There is similar issue can be found on hadoop-mapreduce-dev mailing list:
http://mail-archives.apache.org/mod_mbox/hadoop-mapreduce-dev/201206.mbox/%3CCBF75E52.128E%25nishchay.p@inmobi.com%3E

Haeinsa already depends on `hadoop-common`, so we can exclude `hadoop-common` from `hadoop-hdfs-test` dependency for not to use SNAPSHOT release.
