### PR TITLE
Refactoring operations to use HaeinsaQuery and HaeinsaOperation

### DIFF
--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaGet.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaGet.java
@@ -28,9 +28,8 @@ import org.apache.hadoop.hbase.util.Bytes;
  * <p>
  * HaeinsaGet only contains data of single row.
  */
-public class HaeinsaGet {
+public class HaeinsaGet extends HaeinsaQuery {
     private byte[] row;
-    private boolean cacheBlocks = true;
     private Map<byte[], NavigableSet<byte[]>> familyMap =
             new TreeMap<byte[], NavigableSet<byte[]>>(Bytes.BYTES_COMPARATOR);
 
@@ -95,13 +94,5 @@ public class HaeinsaGet {
      */
     public Map<byte[], NavigableSet<byte[]>> getFamilyMap() {
         return this.familyMap;
-    }
-
-    public void setCacheBlocks(boolean cacheBlocks) {
-        this.cacheBlocks = cacheBlocks;
-    }
-
-    public boolean getCacheBlocks() {
-        return cacheBlocks;
     }
 }

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaIntraScan.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaIntraScan.java
@@ -31,14 +31,13 @@ import org.apache.hadoop.hbase.util.Bytes;
  * <p>
  * Default batch size is 32.
  */
-public class HaeinsaIntraScan {
+public class HaeinsaIntraScan extends HaeinsaQuery {
     private final byte[] row;
     private final byte[] minColumn;
     private final boolean minColumnInclusive;
     private final byte[] maxColumn;
     private final boolean maxColumnInclusive;
     private int batch = 32;
-    private boolean cacheBlocks = true;
 
     // if this set is empty, then scan every family
     private final NavigableSet<byte[]> families = new TreeSet<byte[]>(Bytes.BYTES_COMPARATOR);
@@ -88,13 +87,5 @@ public class HaeinsaIntraScan {
 
     public NavigableSet<byte[]> getFamilies() {
         return families;
-    }
-
-    public void setCacheBlocks(boolean cacheBlocks) {
-        this.cacheBlocks = cacheBlocks;
-    }
-
-    public boolean getCacheBlocks() {
-        return cacheBlocks;
     }
 }

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaMutation.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaMutation.java
@@ -43,7 +43,7 @@ import com.google.common.collect.Iterables;
  * <p>
  * HaeinsaMutation provides {@link HaeinsaKeyValueScanner} interface by {@link #getScanner()} method.
  */
-public abstract class HaeinsaMutation {
+public abstract class HaeinsaMutation extends HaeinsaOperation {
     protected byte[] row;
     // { family -> HaeinsaKeyValue }
     protected Map<byte[], NavigableSet<HaeinsaKeyValue>> familyMap =

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaOperation.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaOperation.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2013-2014 VCNC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.vcnc.haeinsa;
+
+public abstract class HaeinsaOperation {
+}

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaPut.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaPut.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Sets;
  * HaeinsaPut only contains data of single row.
  */
 public class HaeinsaPut extends HaeinsaMutation {
+
     public HaeinsaPut(byte[] row) {
         this.row = row;
     }

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaQuery.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaQuery.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2013-2014 VCNC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.vcnc.haeinsa;
+
+public abstract class HaeinsaQuery extends HaeinsaOperation {
+    protected boolean cacheBlocks = true;
+
+    /**
+     * Set whether blocks should be cached for this Scan.
+     * Generally caching block help next get/scan requests to the same block,
+     * but DB consume more memory which could cause longer jvm gc or cache churn.
+     * CacheBlocks and caching are different configurations.
+     * <p>
+     * This is true by default. When true, default settings of the table and
+     * family are used (this will never override caching blocks if the block
+     * cache is disabled for that family or entirely).
+     *
+     * @param cacheBlocks if false, default settings are overridden and blocks
+     *        will not be cached
+     */
+    public void setCacheBlocks(boolean cacheBlocks) {
+        this.cacheBlocks = cacheBlocks;
+    }
+
+    /**
+     * Get whether blocks should be cached for this Scan.
+     *
+     * @return true if default setting of block caching should be used, false if
+     *         blocks should not be cached
+     */
+    public boolean getCacheBlocks() {
+        return cacheBlocks;
+    }
+}

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaScan.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaScan.java
@@ -37,11 +37,10 @@ import org.apache.hadoop.hbase.util.Bytes;
  * one time.
  */
 // TODO: Setting batch size will be supported in future....?
-public class HaeinsaScan {
+public class HaeinsaScan extends HaeinsaQuery {
     private byte[] startRow = HConstants.EMPTY_START_ROW;
     private byte[] stopRow = HConstants.EMPTY_END_ROW;
     private int caching = -1;
-    private boolean cacheBlocks = true;
 
     // { family -> qualifier }
     private Map<byte[], NavigableSet<byte[]>> familyMap =
@@ -238,32 +237,4 @@ public class HaeinsaScan {
     public int getCaching() {
         return this.caching;
     }
-
-    /**
-     * Set whether blocks should be cached for this Scan.
-     * Generally caching block help next get/scan requests to the same block,
-     * but DB consume more memory which could cause longer jvm gc or cache churn.
-     * CacheBlocks and caching are different configurations.
-     * <p>
-     * This is true by default. When true, default settings of the table and
-     * family are used (this will never override caching blocks if the block
-     * cache is disabled for that family or entirely).
-     *
-     * @param cacheBlocks if false, default settings are overridden and blocks
-     *        will not be cached
-     */
-    public void setCacheBlocks(boolean cacheBlocks) {
-        this.cacheBlocks = cacheBlocks;
-    }
-
-    /**
-     * Get whether blocks should be cached for this Scan.
-     *
-     * @return true if default setting of block caching should be used, false if
-     *         blocks should not be cached
-     */
-    public boolean getCacheBlocks() {
-        return cacheBlocks;
-    }
-
 }


### PR DESCRIPTION
I create new abstract classes: `HaeinsaOperation` and `HaeinsaQuery`. Now, `HaeinsaGet`, `HaeinsaScan`, `HaeinsaIntraScan` extends `HaeinsaQuery`, And `HaeinsaQuery` and `HaeinsaMutation` extends `HaeinsaOperation`.

This changes are preparing for #10 and #11. `setFilter` will be implemented on `HaeinsaQuery` and `setAttributes` will be implemented on `HaeinsaOperation`.
