### PR TITLE
Adding Thread Safe ability on HaeinsaTransaction for Put / Delete / Get with different hTable

### DIFF
--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaRowTransaction.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaRowTransaction.java
@@ -31,7 +31,8 @@ class HaeinsaRowTransaction {
     // mutations will be saved in order of executions.
     // If this rowTransaction is created during recovering failed transaction by other client,
     // following mutations variable is empty.
-    private final List<HaeinsaMutation> mutations = Lists.newArrayList();
+    private final List<HaeinsaMutation> mutations = createHaeinsaMutations();
+
     private final HaeinsaTableTransaction tableTransaction;
 
     HaeinsaRowTransaction(HaeinsaTableTransaction tableTransaction) {
@@ -91,4 +92,9 @@ class HaeinsaRowTransaction {
         }
         return result;
     }
+
+    protected List<HaeinsaMutation> createHaeinsaMutations() {
+        return Lists.newArrayList();
+    }
+
 }

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaRowTransaction.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaRowTransaction.java
@@ -31,7 +31,7 @@ class HaeinsaRowTransaction {
     // mutations will be saved in order of executions.
     // If this rowTransaction is created during recovering failed transaction by other client,
     // following mutations variable is empty.
-    private final List<HaeinsaMutation> mutations = createHaeinsaMutations();
+    protected final List<HaeinsaMutation> mutations = createHaeinsaMutations();
 
     private final HaeinsaTableTransaction tableTransaction;
 

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaRowTransactionThreadSafe.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaRowTransactionThreadSafe.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2013-2015 VCNC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.vcnc.haeinsa;
+
+/**
+ * Created by ehud on 8/17/15.
+ * We might want to consider optimize the addMutation and use java.util.concurrent list such as CopyOnWriteArrayList
+ */
+class HaeinsaRowTransactionThreadSafe extends HaeinsaRowTransaction {
+
+    HaeinsaRowTransactionThreadSafe(HaeinsaTableTransaction tableTransaction) {
+        super(tableTransaction);
+    }
+
+    @Override
+    public synchronized void addMutation(HaeinsaMutation mutation) {
+        super.addMutation(mutation);
+    }
+
+}

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaRowTransactionThreadSafe.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaRowTransactionThreadSafe.java
@@ -15,19 +15,24 @@
  */
 package kr.co.vcnc.haeinsa;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Created by ehud on 8/17/15.
  * We might want to consider optimize the addMutation and use java.util.concurrent list such as CopyOnWriteArrayList
  */
 class HaeinsaRowTransactionThreadSafe extends HaeinsaRowTransaction {
 
+    private final AtomicBoolean used = new AtomicBoolean(false);
+
     HaeinsaRowTransactionThreadSafe(HaeinsaTableTransaction tableTransaction) {
         super(tableTransaction);
     }
 
-    @Override
-    public synchronized void addMutation(HaeinsaMutation mutation) {
-        super.addMutation(mutation);
+    public void addMutation(HaeinsaMutation mutation) {
+        if (!used.compareAndSet(false, true)) {
+            throw new IllegalStateException("This row was already changed. " +
+                    "Currently not allowed to write more than once to the same row in thread safe mode");
+        }
+        mutations.add(mutation);
     }
-
 }

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaTableTransaction.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaTableTransaction.java
@@ -31,8 +31,9 @@ import com.google.common.collect.Maps;
  * {@link HaeinsaTransaction}
  */
 class HaeinsaTableTransaction {
-    private final NavigableMap<byte[], HaeinsaRowTransaction> rowStates = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-    private final HaeinsaTransaction transaction;
+    protected final NavigableMap<byte[], HaeinsaRowTransaction> rowStates = createHaeinsaRowTransactionNavigableMap();
+
+    protected final HaeinsaTransaction transaction;
 
     HaeinsaTableTransaction(HaeinsaTransaction transaction) {
         this.transaction = transaction;
@@ -71,5 +72,9 @@ class HaeinsaTableTransaction {
             rowStates.put(row, rowState);
         }
         return rowState;
+    }
+
+    protected NavigableMap<byte[], HaeinsaRowTransaction> createHaeinsaRowTransactionNavigableMap() {
+        return Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
     }
 }

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaTableTransactionThreadSafe.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaTableTransactionThreadSafe.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2013-2015 VCNC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.vcnc.haeinsa;
+
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.util.NavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * Created by ehud on 8/17/15
+ * Extends .{@link HaeinsaTableTransaction} and added the ability to call createOrGetRowState from multi threads
+ * <p>
+ * It have map of {byte[] row -> {@link HaeinsaRowTransaction} and reference to
+ * {@link HaeinsaTransactionThreadSafe}
+ */
+public class HaeinsaTableTransactionThreadSafe extends HaeinsaTableTransaction {
+
+    HaeinsaTableTransactionThreadSafe(HaeinsaTransaction transaction) {
+        super(transaction);
+    }
+
+    /**
+     * overrides {@link HaeinsaTableTransaction} in order to be thread safe.
+     * @return RowTransaction - {@link HaeinsaRowTransaction} which contained in
+     * this instance.
+     */
+    @Override
+    public HaeinsaRowTransaction createOrGetRowState(byte[] row) {
+        HaeinsaRowTransaction rowState = rowStates.get(row);
+        if (rowState == null) {
+            synchronized (rowStates){
+                rowState = rowStates.get(row);
+                if (rowState == null) {
+                    rowState = new HaeinsaRowTransactionThreadSafe(this);
+                    rowStates.put(row, rowState);
+                }
+            }
+        }
+        return rowState;
+    }
+
+    protected NavigableMap<byte[], HaeinsaRowTransaction> createHaeinsaRowTransactionNavigableMap() {
+        return new ConcurrentSkipListMap<byte[], HaeinsaRowTransaction>(Bytes.BYTES_COMPARATOR);
+    }
+}

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaTransaction.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaTransaction.java
@@ -51,8 +51,7 @@ import com.google.common.hash.Hashing;
  */
 public class HaeinsaTransaction {
     private static final Logger LOGGER = LoggerFactory.getLogger(HaeinsaTransaction.class);
-    private final HaeinsaTransactionState txStates = new HaeinsaTransactionState();
-
+    protected final HaeinsaTransactionState txStates = createTransactionState();
     private final HaeinsaTransactionManager manager;
     private TRowKey primary;
     private long commitTimestamp = Long.MIN_VALUE;
@@ -519,6 +518,10 @@ public class HaeinsaTransaction {
         txStates.classifyAndSortRows(onRecovery);
     }
 
+   protected HaeinsaTransactionState createTransactionState() {
+        return new HaeinsaTransactionState();
+    }
+
     /**
      * Container which contain {byte[] : {@link HaeinsaTableTransaction} map.
      * <p>
@@ -529,8 +532,8 @@ public class HaeinsaTransaction {
      * {@link TRowLockState#STABLE}, then that row is MutationRow. ReadOnlyRow
      * otherwise (There is no mutations, and state is STABLE).
      */
-    private static class HaeinsaTransactionState {
-        private final NavigableMap<byte[], HaeinsaTableTransaction> tableStates = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    protected static class HaeinsaTransactionState {
+        protected final NavigableMap<byte[], HaeinsaTableTransaction> tableStates = createTablesStates();
         private final Comparator<TRowKey> comparator = new HashComparator();
         private NavigableMap<TRowKey, HaeinsaRowTransaction> mutationRowStates = null;
         private NavigableMap<TRowKey, HaeinsaRowTransaction> readOnlyRowStates = null;
@@ -644,6 +647,10 @@ public class HaeinsaTransaction {
                     }
                 }
             }
+        }
+
+        protected NavigableMap<byte[], HaeinsaTableTransaction> createTablesStates() {
+            return Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
         }
     }
 

--- a/src/main/java/kr/co/vcnc/haeinsa/HaeinsaTransactionThreadSafe.java
+++ b/src/main/java/kr/co/vcnc/haeinsa/HaeinsaTransactionThreadSafe.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2013-2015 VCNC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.vcnc.haeinsa;
+
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.util.NavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+/**
+ * Created by ehud on 8/17/15.
+ * Representation of single transaction in Haeinsa. extends {@link HaeinsaTransaction}
+ * It contains {@link HaeinsaTableTransactionThreadSafe}s to include information of overall transaction,
+ * and have reference to {@link HaeinsaTransactionManager} which created this instance.
+ * <p>
+ * ThreadSafeHaeinsaTransaction can be generated via calling {@link HaeinsaTransactionManager#begin()}
+ * or {@link HaeinsaTransactionManager#getTransaction(byte[], byte[])}.
+ * Former is used when start new transaction, later is used when try to roll back or retry failed transaction.
+ * <p>
+ * One {@link HaeinsaTransactionThreadSafe} can't be used after calling {@link #commit()} or {@link #rollback()} is called.
+ */
+public class HaeinsaTransactionThreadSafe extends HaeinsaTransaction {
+
+    public HaeinsaTransactionThreadSafe(HaeinsaTransactionManager manager) {
+        super(manager);
+    }
+
+    @Override
+    protected HaeinsaTableTransaction createOrGetTableState(byte[] tableName) {
+        HaeinsaTableTransaction tableTxState = txStates.getTableStates().get(tableName);
+        if (tableTxState == null) {
+            synchronized (txStates){
+                tableTxState = txStates.getTableStates().get(tableName);
+                if (tableTxState == null) {
+                    tableTxState = new HaeinsaTableTransactionThreadSafe(this);
+                    txStates.getTableStates().put(tableName, tableTxState);
+                }
+            }
+        }
+        return tableTxState;
+    }
+
+    @Override
+    protected HaeinsaTransactionState createTransactionState() {
+        return new ThreadSafeHaeinsaTransactionState();
+    }
+
+    protected static class ThreadSafeHaeinsaTransactionState extends HaeinsaTransactionState{
+
+        @Override
+        protected NavigableMap<byte[], HaeinsaTableTransaction> createTablesStates() {
+            return new ConcurrentSkipListMap<byte[], HaeinsaTableTransaction>(Bytes.BYTES_COMPARATOR);
+        }
+    }
+}

--- a/src/test/java/kr/co/vcnc/haeinsa/HaeinsaTransactionMultiThreadTest.java
+++ b/src/test/java/kr/co/vcnc/haeinsa/HaeinsaTransactionMultiThreadTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2013-2015 VCNC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kr.co.vcnc.haeinsa;
+
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Ignore;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+
+
+public class HaeinsaTransactionMultiThreadTest extends HaeinsaTestBase {
+    @Ignore//This test fails. as an example for the reason we need the threadSafe transaction
+    @Test
+    public void testChangesAsExpected() throws Exception {
+        final HaeinsaTransactionManager tm = context().getTransactionManager();
+        final HaeinsaTableIface table = context().getHaeinsaTableIface("test");
+        int conccurency = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        FutureTask<Void>[] tasks = new FutureTask[conccurency];
+        // Tests multi-row mutation transaction
+        {
+            final HaeinsaTransaction tx = tm.begin();
+            Assert.assertFalse(tx.hasChanges());
+            for (int i = 0; i < conccurency; i++){
+                final String callId = i + "";
+                tasks[i] = new FutureTask<Void>(new Callable<Void>(){
+                    HaeinsaTransaction trx = tx;
+                    String id = callId;
+                    final HaeinsaTableIface table = trx.getManager().getTablePool().getTable(context().createContextedTableName("test"));
+
+                    @Override
+                    public Void call() throws Exception {
+                        HaeinsaDelete delete1 = new HaeinsaDelete(Bytes.toBytes("row1" + id));
+                        delete1.deleteFamily(Bytes.toBytes("data"));
+                        table.delete(tx, delete1);
+
+                        HaeinsaPut put1 = new HaeinsaPut(Bytes.toBytes("row2" + id));
+                        put1.add(Bytes.toBytes("data"), Bytes.toBytes("qualifier"), Bytes.toBytes("value"));
+                        table.put(tx, put1);
+                        table.close();
+                        return null;
+                    }
+                });
+            }
+            for (int i = 0; i < conccurency; i++){
+                //running all tasks
+                executor.execute(tasks[i]);
+            }
+            for (int i = 0; i < conccurency; i++){
+                //waiting for all to finish
+                tasks[i].get();
+            }
+            tx.classifyAndSortRows(true);
+            Assert.assertEquals(tx.getMutationRowStates().size(), conccurency * 2);
+        }
+    }
+
+    @Test
+    public void testChangesAsExpected2() throws Exception {
+        final HaeinsaTransactionManager tm = context().getTransactionManager();
+        final HaeinsaTransactionManager threadSafetm = new HaeinsaTransactionManager(context().getTransactionManager().getTablePool(), true);
+        final HaeinsaTableIface table = context().getHaeinsaTableIface("test");
+        int conccurency = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        FutureTask<Void>[] tasks = new FutureTask[conccurency];
+        // Tests multi-row mutation transaction
+        {
+            final HaeinsaTransaction tx = threadSafetm.begin();
+            Assert.assertFalse(tx.hasChanges());
+            for (int i = 0; i < conccurency; i++){
+                final String callId = i + "";
+                tasks[i] = new FutureTask<Void>(new Callable<Void>(){
+                    HaeinsaTransaction trx = tx;
+                    String id = callId;
+                    final HaeinsaTableIface table = trx.getManager().getTablePool().getTable(context().createContextedTableName("test"));
+
+                    @Override
+                    public Void call() throws Exception {
+                        HaeinsaDelete delete1 = new HaeinsaDelete(Bytes.toBytes("row1" + id));
+                        delete1.deleteFamily(Bytes.toBytes("data"));
+                        table.delete(tx, delete1);
+
+                        HaeinsaPut put1 = new HaeinsaPut(Bytes.toBytes("row2" + id));
+                        put1.add(Bytes.toBytes("data"), Bytes.toBytes("qualifier"), Bytes.toBytes("value"));
+                        table.put(tx, put1);
+                        table.close();
+                        return null;
+                    }
+                });
+            }
+            for (int i = 0; i < conccurency; i++){
+                //running all tasks
+                executor.execute(tasks[i]);
+            }
+            for (int i = 0; i < conccurency; i++){
+                //waiting for all to finish
+                tasks[i].get();
+            }
+            tx.classifyAndSortRows(true);
+            Assert.assertEquals(tx.getMutationRowStates().size(), conccurency * 2);
+        }
+    }
+}


### PR DESCRIPTION
Currently we cannot run the following scenario:
1. Create manager.// one thread
2. Begin transaction. // one thread
3. Run: 
   Put / Delete / Get. // with the same transaction with different threads.
4. On success of all Threads -> commit // one thread.

The fix I am suggesting will not change the current API at all, it will only add the ability to use some locks on mutation collections (using java.concurrent library).

I added a test to illustrate the scenario. 

We would appreciate it if you would pull the attached code. Furthermore, any feedback would be welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vcnc/haeinsa/48)
<!-- Reviewable:end -->
